### PR TITLE
docs: binds and punctuation corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ class MyComponent extends Component {
   render() {
     return html`
       <span>The current date is ${this.state.date}</span>
-      <button onclick=${this.updateDate}>Update Date</button>
+      <button onclick=${() => this.updateDate()}>Update Date</button>
     `;
   }
 
-  updateDate = () => {
+  updateDate() {
     this.state.date = new Date();
   };
 }

--- a/README.md
+++ b/README.md
@@ -157,25 +157,24 @@ You can set the initial state in the constructor or the didLoad method. When usi
 import { html, Component } from "jolt";
 
 class MyComponent extends Component {
+  constructor() {
+    super();
 
-    constructor() {
-        super();
+    this.state.set({
+      date: new Date(),
+    });
+  }
 
-        this.state.set({
-            date: new Date();
-        });
-    }
+  render() {
+    return html`
+      <span>The current date is ${this.state.date}</span>
+      <button onclick=${this.updateDate}>Update Date</button>
+    `;
+  }
 
-    render() {
-        return html`
-            <span>The current date is ${this.state.date}</span>
-            <button onclick=${this.updateDate}>Update Date</button>
-        `;
-    }
-
-    updateDate() {
-        this.state.date = new Date();
-    }
+  updateDate = () => {
+    this.state.date = new Date();
+  };
 }
 ```
 


### PR DESCRIPTION
- removed `;` internal to object notation
- changed `updateDate` to class property to with fat arrow notation to ensure bind to `this`