### PR TITLE
fix: added bodyParser for parsing request body.

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -41,7 +41,9 @@ CLI Options:
 
 ## JavaScript Usage
 
-You can use @jolt/server in your JavaScript file and pass it the same options as the cli as well as a custom `headers` property.
+You can use @jolt/server in your JavaScript file and pass it the same options as the cli as well as a custom `headers` or `bodyParser` property.
+
+The `bodyParser` property allows you to set a custom function for parsing the request body. The value returned by the bodyParser is assigned to `req.body`.
 
 **Example:**
 ```js
@@ -55,7 +57,8 @@ server({
     spa: true,
     headers: {
         "Cache-Control": "no-cache"
-    }
+    },
+    bodyParser: (data) => JSON.parse(data)
 });
 ```
 

--- a/packages/server/src/modules/WebServer.js
+++ b/packages/server/src/modules/WebServer.js
@@ -33,6 +33,7 @@ export class WebServer {
         this._key = Parser.getArg("key", null, null, args);
         this._cert = Parser.getArg("cert", null, null, args);
         this._headers = Parser.getArg("headers", null, {}, args);
+        this._bodyParser = Parser.getArg("bodyParser", null, (data) => data, args);
     }
 
     /** Starts the WebServer. */
@@ -133,7 +134,7 @@ export class WebServer {
             });
 
             req.on("end", () => {
-                resolve(JSON.parse(body));
+                resolve(this._bodyParser(body));
             });
         });
     }

--- a/packages/server/types/api.d.ts
+++ b/packages/server/types/api.d.ts
@@ -2,6 +2,8 @@ declare interface Headers {
     [key: string]: string;
 }
 
+declare type ParserCallback = (data: string) => any;
+
 declare interface Options {
     port?: number,
     root?: string,
@@ -10,7 +12,8 @@ declare interface Options {
     spa?: boolean,
     key?: string,
     cert?: string,
-    headers?: Headers
+    headers?: Headers,
+    bodyParser: ParserCallback
 }
 
 declare type ResponseCallback = (req: any, res: any) => void;


### PR DESCRIPTION
This pull request adds the `bodyParser` option to @jolt/server, this lets developers set a custom function for what format they want the request body to be in. by default its parsed into a string.