### PR TITLE
Add code-splitting for toolchains

### DIFF
--- a/packages/toolchain-javascript/rollup.config.js
+++ b/packages/toolchain-javascript/rollup.config.js
@@ -7,34 +7,50 @@ import { terser } from "rollup-plugin-terser";
 import { dependencies } from "./package.json";
 import { builtinModules } from "module";
 
-/* build config */
-export default {
-    input: "src/index.js",
-    output: { file: "dist/toolchain.js", format: "cjs" },
-    plugins: [
-        babel({
-            babelHelpers: "bundled",
-            exclude: "node_modules/**",
-            presets: [
-                [
-                    "@babel/preset-env",
-                    {
-                        "targets": {
-                            "node": "10.6"
-                        }
+const plugins = [
+    babel({
+        babelHelpers: "bundled",
+        exclude: "node_modules/**",
+        presets: [
+            [
+                "@babel/preset-env",
+                {
+                    "targets": {
+                        "node": "10.6"
                     }
-                ]
-            ],
-            plugins: ["@babel/plugin-proposal-class-properties"]
-        }),
-        resolve(),
-        commonjs(),
-        json(),
-        terser({
-            output: {
-                preamble: "/* Copyright (c) 2020 Outwalk Studios */"
-            }
-        })
-    ],
-    external: Object.keys(dependencies).concat(builtinModules)
-}
+                }
+            ]
+        ],
+        plugins: ["@babel/plugin-proposal-class-properties"]
+    }),
+    resolve(),
+    commonjs(),
+    json(),
+    terser({
+        output: {
+            preamble: "/* Copyright (c) 2020 Outwalk Studios */"
+        }
+    })
+];
+const external = Object.keys(dependencies).concat(builtinModules)
+
+/* build config */
+export default [
+    {
+        input: "src/index.js",
+        output: { file: "dist/toolchain.js", format: "cjs" },
+        plugins,
+        external, 
+    },
+    {
+        input: [
+            "src/cmd/build.js",
+            "src/cmd/watch.js",
+            "src/cmd/lint.js",
+            "src/cmd/serve.js"
+        ],
+        output: { dir: "dist/cmd", format: "cjs", exports: "default" },
+        plugins,
+        external,
+    }
+]

--- a/packages/toolchain-typescript/rollup.config.js
+++ b/packages/toolchain-typescript/rollup.config.js
@@ -7,34 +7,50 @@ import { terser } from "rollup-plugin-terser";
 import { dependencies } from "./package.json";
 import { builtinModules } from "module";
 
-/* build config */
-export default {
-    input: "src/index.js",
-    output: { file: "dist/toolchain.js", format: "cjs" },
-    plugins: [
-        babel({
-            babelHelpers: "bundled",
-            exclude: "node_modules/**",
-            presets: [
-                [
-                    "@babel/preset-env",
-                    {
-                        "targets": {
-                            "node": "10.6"
-                        }
+const plugins = [
+    babel({
+        babelHelpers: "bundled",
+        exclude: "node_modules/**",
+        presets: [
+            [
+                "@babel/preset-env",
+                {
+                    "targets": {
+                        "node": "10.6"
                     }
-                ]
-            ],
-            plugins: ["@babel/plugin-proposal-class-properties"]
-        }),
-        resolve(),
-        commonjs(),
-        json(),
-        terser({
-            output: {
-                preamble: "/* Copyright (c) 2020 Outwalk Studios */"
-            }
-        })
-    ],
-    external: Object.keys(dependencies).concat(builtinModules)
-}
+                }
+            ]
+        ],
+        plugins: ["@babel/plugin-proposal-class-properties"]
+    }),
+    resolve(),
+    commonjs(),
+    json(),
+    terser({
+        output: {
+            preamble: "/* Copyright (c) 2020 Outwalk Studios */"
+        }
+    })
+];
+const external = Object.keys(dependencies).concat(builtinModules)
+
+/* build config */
+export default [
+    {
+        input: "src/index.js",
+        output: { file: "dist/toolchain.js", format: "cjs" },
+        plugins,
+        external,
+    },
+    {
+        input: [
+            "src/cmd/build.js",
+            "src/cmd/watch.js",
+            "src/cmd/lint.js",
+            "src/cmd/serve.js"
+        ],
+        output: { dir: "dist/cmd", format: "cjs", exports: "default" },
+        plugins,
+        external,
+    }
+]


### PR DESCRIPTION
Related issue: #17 

Current `dist` folder looks like below:

![Screen Shot 2020-10-28 at 16 41 00](https://user-images.githubusercontent.com/16080180/97443707-664d3480-193c-11eb-9896-d6744a79b749.png)
